### PR TITLE
mismatch between config and how we call dp-cache

### DIFF
--- a/pkg/navigation/client/clients.go
+++ b/pkg/navigation/client/clients.go
@@ -12,7 +12,7 @@ import (
 
 // Clienter is an interface with methods required for navigation cache
 type Clienter interface {
-	AddNavigationCache(ctx context.Context, updateInterval time.Duration) error
+	AddNavigationCache(ctx context.Context, updateInterval *time.Duration) error
 	GetNavigationData(ctx context.Context, lang string) (*topicModel.Navigation, error)
 	Close()
 	StartBackgroundUpdate(ctx context.Context, errorChannel chan error)

--- a/pkg/navigation/client/mock_navigation_clienter.go
+++ b/pkg/navigation/client/mock_navigation_clienter.go
@@ -40,7 +40,7 @@ var _ Clienter = &ClienterMock{}
 //	}
 type ClienterMock struct {
 	// AddNavigationCacheFunc mocks the AddNavigationCache method.
-	AddNavigationCacheFunc func(ctx context.Context, updateInterval time.Duration) error
+	AddNavigationCacheFunc func(ctx context.Context, updateInterval *time.Duration) error
 
 	// CloseFunc mocks the Close method.
 	CloseFunc func()
@@ -85,7 +85,7 @@ type ClienterMock struct {
 }
 
 // AddNavigationCache calls AddNavigationCacheFunc.
-func (mock *ClienterMock) AddNavigationCache(ctx context.Context, updateInterval time.Duration) error {
+func (mock *ClienterMock) AddNavigationCache(ctx context.Context, updateInterval *time.Duration) error {
 	if mock.AddNavigationCacheFunc == nil {
 		panic("ClienterMock.AddNavigationCacheFunc: method is nil but Clienter.AddNavigationCache was just called")
 	}
@@ -94,7 +94,7 @@ func (mock *ClienterMock) AddNavigationCache(ctx context.Context, updateInterval
 		UpdateInterval time.Duration
 	}{
 		Ctx:            ctx,
-		UpdateInterval: updateInterval,
+		UpdateInterval: *updateInterval,
 	}
 	mock.lockAddNavigationCache.Lock()
 	mock.calls.AddNavigationCache = append(mock.calls.AddNavigationCache, callInfo)

--- a/pkg/navigation/client/publishing.go
+++ b/pkg/navigation/client/publishing.go
@@ -25,8 +25,8 @@ func NewPublishingClient(ctx context.Context, clients *Clients, languages []stri
 	}
 }
 
-func (hpc *PublishingClient) AddNavigationCache(ctx context.Context, updateInterval time.Duration) error {
-	navigationCache, err := cache.NewNavigationCache(ctx, &updateInterval)
+func (hpc *PublishingClient) AddNavigationCache(ctx context.Context, updateInterval *time.Duration) error {
+	navigationCache, err := cache.NewNavigationCache(ctx, updateInterval)
 	if err != nil {
 		log.Error(ctx, "failed to create navigation cache", err, log.Data{"update_interval": updateInterval})
 		return err

--- a/pkg/navigation/client/web.go
+++ b/pkg/navigation/client/web.go
@@ -16,7 +16,7 @@ type WebClient struct {
 	languages       []string
 }
 
-func NewWebClient(ctx context.Context, clients *Clients, updateInterval time.Duration, languages []string) (Clienter, error) {
+func NewWebClient(ctx context.Context, clients *Clients, languages []string) (Clienter, error) {
 	return &WebClient{
 		Updater: Updater{
 			clients: clients,
@@ -25,8 +25,8 @@ func NewWebClient(ctx context.Context, clients *Clients, updateInterval time.Dur
 	}, nil
 }
 
-func (hwc *WebClient) AddNavigationCache(ctx context.Context, updateInterval time.Duration) error {
-	navigationCache, err := cache.NewNavigationCache(ctx, &updateInterval)
+func (hwc *WebClient) AddNavigationCache(ctx context.Context, updateInterval *time.Duration) error {
+	navigationCache, err := cache.NewNavigationCache(ctx, updateInterval)
 	if err != nil {
 		log.Error(ctx, "failed to create navigation cache", err, log.Data{"update_interval": updateInterval})
 		return err

--- a/pkg/navigation/helper/helper.go
+++ b/pkg/navigation/helper/helper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-
 type Helper struct {
 	Clienter  client.Clienter
 	Config    Config
@@ -24,7 +23,7 @@ type Helper struct {
 
 type Config struct {
 	APIRouterURL                string
-	CacheUpdateInterval         time.Duration
+	CacheUpdateInterval         *time.Duration
 	EnableNewNavBar             bool
 	EnableCensusTopicSubsection bool
 	CensusTopicID               string
@@ -34,7 +33,6 @@ type Config struct {
 }
 
 func Init(ctx context.Context, cfg Config) (svc *Helper, err error) {
-
 	svc = &Helper{}
 	svc.CacheList = cache.List{}
 	svc.Clients = &client.Clients{
@@ -45,21 +43,21 @@ func Init(ctx context.Context, cfg Config) (svc *Helper, err error) {
 	if svc.Config.IsPublishingMode {
 		svc.Clienter = client.NewPublishingClient(ctx, svc.Clients, cfg.Languages)
 	} else {
-		svc.Clienter, err = client.NewWebClient(ctx, svc.Clients, cfg.CacheUpdateInterval, cfg.Languages)
+		svc.Clienter, err = client.NewWebClient(ctx, svc.Clients, cfg.Languages)
 		if err != nil {
 			log.Fatal(ctx, "failed to create homepage web client", err)
 			return
 		}
 	}
-	if err = svc.Clienter.AddNavigationCache(ctx, cfg.CacheUpdateInterval); err != nil {
-		log.Fatal(ctx, "failed to add navigation cache to homepage client", err)
+	if err = svc.Clienter.AddNavigationCache(ctx, svc.Config.CacheUpdateInterval); err != nil {
+		log.Fatal(ctx, "failed to add navigation cache", err)
 		return
 	}
 
 	if svc.Config.EnableCensusTopicSubsection {
 		// Initialise caching census topics
 		cache.CensusTopicID = svc.Config.CensusTopicID
-		svc.CacheList.CensusTopic, err = cache.NewTopicCache(ctx, &svc.Config.CacheUpdateInterval)
+		svc.CacheList.CensusTopic, err = cache.NewTopicCache(ctx, svc.Config.CacheUpdateInterval)
 		if err != nil {
 			log.Error(ctx, "failed to create topics cache", err)
 			return


### PR DESCRIPTION
dp-cache expects `UpdateInterval == nil` if you only want to set the cache at startup.  

Our config files aren't using pointers at the moment, and default to 0.  This is the asiest short time fix.