### PR TITLE
Downgrade go to 1.24

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.25.1-bookworm
+    tag: 1.24.10-bookworm
 
 inputs:
   - name: dp-frontend-cache-helper

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.25.1-bookworm-golangci-lint-2
+    tag: 1.24.10-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-frontend-cache-helper

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.25.1-bookworm
+    tag: 1.24.10-bookworm
 
 inputs:
   - name: dp-frontend-cache-helper

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/ONSdigital/dp-frontend-cache-helper
 
-go 1.25
+go 1.24.0
 
 require (
-	github.com/ONSdigital/dis-design-system-go v1.0.0
+	github.com/ONSdigital/dis-design-system-go v1.3.0
 	github.com/ONSdigital/dp-cache v0.4.0
 	github.com/ONSdigital/dp-topic-api v0.23.0
 	github.com/ONSdigital/log.go/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/ONSdigital/dis-design-system-go v1.0.0 h1:mxWuZzr3cxzNNCNMN1jLqK2nAr+nZt4zim/l/F0AThQ=
-github.com/ONSdigital/dis-design-system-go v1.0.0/go.mod h1:9ERtk4XWBSLhO5N+3Ea6gfhv+o10I4gxxBqmnHZNE/Y=
+github.com/ONSdigital/dis-design-system-go v1.3.0 h1:pg0lrH7NuYXBPk/rjYroXBZfRgbQ594hSGHy2CEXg2Q=
+github.com/ONSdigital/dis-design-system-go v1.3.0/go.mod h1:r6bXYLXydqNMpYDKcz6CKaVH2Kbq3XIxMyGlbicE0Xc=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.269.0 h1:13QGPBu/NmIwmPhSP0yTlPEp/U1u22dEdyi8lN5guhA=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.269.0/go.mod h1:bLseTP21r8LCStUEeOdVPyqtrTomOFP/azPjKWW4deA=
 github.com/ONSdigital/dp-cache v0.4.0 h1:Y9uHFlvayzHPHLXmfMR+wwPLXanwYqsLeG6O8ix5mT0=


### PR DESCRIPTION
### What

Downgrade go to 1.24.10 in CI files and 1.24.0 in go.mod
Used in dp-frontend-feedback-controller so needs to be downgraded here, so feedback-controller can also use 1.24

### How to review

See if all okay/passes
Ensure CI passes
Sense check

### Who can review

Not me.